### PR TITLE
Backport to Minecraft 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     implementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-    implementation "com.terraformersmc:modmenu:18.0.0-alpha.8"
+    implementation "com.terraformersmc:modmenu:8.0.0-rc.1"
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'net.fabricmc.fabric-loom' version '1.15-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom' version '1.5.0'
     id 'maven-publish'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'net.fabricmc.fabric-loom' version '1.5.0'
+    id 'net.fabricmc.fabric-loom' version '0.14.8'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1
-loader_version=0.18.1
+minecraft_version=1.21
+loader_version=0.15.11
 loom_version=1.14-SNAPSHOT
 
 # Mod Properties
-mod_version=1.1.7-mc26.1
+mod_version=1.1.7-mc1.21
 maven_group=udpsendtofailed.modmenu.updater
 archives_base_name=modmenu_updater
 
 # Dependencies
-fabric_version=0.138.3+1.21.11
+fabric_version=0.105.2+1.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.configuration-cache=false
 # check these on https://fabricmc.net/develop
 minecraft_version=1.21
 loader_version=0.15.11
-loom_version=1.14-SNAPSHOT
+loom_version=1.5.0
 
 # Mod Properties
 mod_version=1.1.7-mc1.21

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,9 +23,9 @@
   ],
   "accessWidener": "modmenu_updater.accesswidener",
   "depends": {
-    "fabricloader": ">=0.14.0",
-    "minecraft": ">=1.21.11-",
+    "fabricloader": ">=0.15.11",
+    "minecraft": ">=1.21-",
     "java": ">=17",
-    "modmenu": "=18.0.0-alpha.8"
+    "modmenu": "=8.0.0-rc.1"
   }
 }


### PR DESCRIPTION
- Changed Minecraft version to 1.21
- Updated to ModMenu 8.0.0-rc.1 for 1.21 
- Made the mixins compatible with the 1.21 API